### PR TITLE
added maximum clique solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ option(CLIPPER_BUILD_TESTS "Build testsuite" OFF)
 option(CLIPPER_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option(CLIPPER_ENABLE_MKL "Use MKL with Eigen" OFF)
 option(CLIPPER_ENABLE_BLAS "Use BLAS with Eigen" OFF) # apt install libopenblas-dev
+option(CLIPPER_ENABLE_MAXCLIQUE "Use PMC lib for solveAsMaximumClique" ON)
+option(CLIPPER_ENABLE_SCS_SDR "Use SCS lib for solveAsMSRCSDR" ON)
 
 if(CLIPPER_ENABLE_MKL AND CLIPPER_ENABLE_BLAS)
   message(FATAL_ERROR "Cannot enable both MKL and BLAS (prefer MKL)")
@@ -69,6 +71,13 @@ if(CLIPPER_BUILD_BINDINGS_PYTHON)
   FetchContent_MakeAvailable(pybind11)
 endif()
 
+if(CLIPPER_ENABLE_MAXCLIQUE)
+    FetchContent_Declare(pmc
+        GIT_REPOSITORY  https://github.com/jingnanshi/pmc
+        GIT_TAG         16af470353a784352760ec2deea25fa7ed602450)
+    FetchContent_MakeAvailable(pmc)
+endif()
+
 ###############################################################################
 # Targets
 ###############################################################################
@@ -77,6 +86,7 @@ add_library(clipper SHARED)
 target_sources(clipper PRIVATE
   src/clipper.cpp
   src/utils.cpp
+  src/maxclique.cpp
   src/invariants/euclidean_distance.cpp
   src/invariants/pointnormal_distance.cpp)
 target_link_libraries(clipper PUBLIC Eigen3::Eigen)
@@ -96,6 +106,11 @@ if(MKL_FOUND)
 elseif(BLAS_FOUND)
     target_compile_definitions(clipper PRIVATE -DEIGEN_USE_BLAS=1)
     target_link_libraries(clipper PRIVATE BLAS::BLAS)
+endif()
+
+if(CLIPPER_ENABLE_MAXCLIQUE)
+    target_compile_definitions(clipper PUBLIC CLIPPER_HAS_PMC)
+    target_link_libraries(clipper PRIVATE pmc)
 endif()
 
 ###############################################################################

--- a/bindings/python/py_clipper.cpp
+++ b/bindings/python/py_clipper.cpp
@@ -111,6 +111,18 @@ PYBIND11_MODULE(clipperpy, m)
   py::module m_utils = m.def_submodule("utils");
   pybind_utils(m_utils);
 
+  py::class_<clipper::maxclique::Params>(m, "MCParams")
+    .def(py::init<>())
+    .def("__repr__", [](const clipper::maxclique::Params &params) {
+      std::ostringstream repr;
+      repr << "<CLIPPER Maximum Clique Parameters>";
+      return repr.str();
+    })
+    .def_readwrite("method", &clipper::maxclique::Params::method)
+    .def_readwrite("threads", &clipper::maxclique::Params::threads)
+    .def_readwrite("time_limit", &clipper::maxclique::Params::time_limit)
+    .def_readwrite("verbose", &clipper::maxclique::Params::verbose);
+
   py::class_<clipper::Params>(m, "Params")
     .def(py::init<>())
     .def("__repr__", [](const clipper::Params &params) {
@@ -166,6 +178,8 @@ PYBIND11_MODULE(clipperpy, m)
           "D1"_a.noconvert(), "D2"_a.noconvert(), "A"_a.noconvert())
     .def("solve", &clipper::CLIPPER::solve,
           "u0"_a.noconvert()=Eigen::VectorXd())
+    .def("solve_as_maximum_clique", &clipper::CLIPPER::solveAsMaximumClique,
+          "params"_a=clipper::maxclique::Params{})
     .def("get_initial_associations", &clipper::CLIPPER::getInitialAssociations)
     .def("get_selected_associations", &clipper::CLIPPER::getSelectedAssociations)
     .def("get_solution", &clipper::CLIPPER::getSolution)

--- a/include/clipper/clipper.h
+++ b/include/clipper/clipper.h
@@ -15,6 +15,8 @@
 #include "clipper/invariants/builtins.h"
 #include "clipper/types.h"
 
+#include "clipper/maxclique.h"
+
 namespace clipper {
 
   /**
@@ -76,7 +78,20 @@ namespace clipper {
                                   const invariants::Data& D2,
                                   const Association& A = Association());
 
+    /**
+     * @brief      Solves the MSRC problem using
+     * graduated projected gradient ascent
+     *
+     * @param[in]  u0    Initial condition, if none provided random vec is used
+     */
     void solve(const Eigen::VectorXd& u0 = Eigen::VectorXd());
+
+    /**
+     * @brief      Solves the maximum clique problem
+     *
+     * @param[in]  params Clique solver parameters
+     */
+    void solveAsMaximumClique(const maxclique::Params& params = {});
 
     const Solution& getSolution() const { return soln_; }
     Affinity getAffinityMatrix();

--- a/include/clipper/maxclique.h
+++ b/include/clipper/maxclique.h
@@ -1,0 +1,28 @@
+/**
+ * @file maxclique.h
+ * @brief Library for solving maximum clique
+ * @author Parker Lusk <plusk@mit.edu>
+ * @date 20 December 2021
+ */
+
+#include <vector>
+
+#include <Eigen/Dense>
+
+namespace clipper {
+namespace maxclique {
+
+enum class Method { EXACT, HEU, KCORE };
+
+struct Params
+{
+  Method method = Method::EXACT; ///< EXACT is ROBIN*, KCORE is ROBIN
+  size_t threads = 24; ///< num threads for OpenMP to use
+  int time_limit = 3600; ///< [s], maximum time allotted for MCP solving
+  bool verbose = false;
+};
+
+std::vector<int> solve(const Eigen::MatrixXd& A, const Params& params = {});
+
+} // ns maxclique
+} // ns clipper

--- a/include/clipper/utils.h
+++ b/include/clipper/utils.h
@@ -124,6 +124,11 @@ namespace utils {
       total_ = 0;
     }
 
+    double getElapsedSeconds() const
+    {
+      return total_;
+    }
+
   private:
     double total_ = 0;
     std::string name_;

--- a/src/clipper.cpp
+++ b/src/clipper.cpp
@@ -79,6 +79,24 @@ void CLIPPER::solve(const Eigen::VectorXd& _u0)
 
 // ----------------------------------------------------------------------------
 
+void CLIPPER::solveAsMaximumClique(const maxclique::Params& params)
+{
+  Eigen::MatrixXd C = getConstraintMatrix();
+
+  utils::Timer tim;
+  tim.start();
+  std::vector<int> nodes = maxclique::solve(C, params);
+  tim.stop();
+
+  soln_.t = tim.getElapsedSeconds();
+  soln_.ifinal = 0;
+  std::swap(soln_.nodes, nodes);
+  soln_.u = Eigen::VectorXd::Zero(M_.cols());
+  soln_.score = -1;
+}
+
+// ----------------------------------------------------------------------------
+
 Association CLIPPER::getInitialAssociations()
 {
   return A_;

--- a/src/maxclique.cpp
+++ b/src/maxclique.cpp
@@ -138,6 +138,9 @@ std::vector<int> solve(const Eigen::MatrixXd& A, const Params& params)
     }
     if (!params.verbose) std::cout.rdbuf(oldbuf);
   }
+#else
+  std::cout << "Warning: PMC was not built with CLIPPER, "
+               "maximum clique will not be found" << std::endl;
 #endif
 
   return C;

--- a/src/maxclique.cpp
+++ b/src/maxclique.cpp
@@ -1,0 +1,147 @@
+/**
+ * @file maxclique.cpp
+ * @brief Library for solving maximum clique
+ * @author Parker Lusk <plusk@mit.edu>
+ * @date 20 December 2021
+ */
+
+#include <iostream>
+
+#include "clipper/maxclique.h"
+
+#ifdef CLIPPER_HAS_PMC
+#include <pmc/pmc.h>
+#endif
+
+namespace clipper {
+namespace maxclique {
+
+#ifdef CLIPPER_HAS_PMC
+pmc::pmc_graph pmc_graph_from_adjmat(const Eigen::MatrixXd& A)
+{
+  // Create a PMC graph from the adjacency matrix
+  std::vector<int> edges;
+  std::vector<long long> vertices;
+  vertices.push_back(0);
+
+  const size_t n = A.rows();
+  size_t total_num_edges = 0;
+  for (size_t i=0; i<n; i++) {
+    for (size_t j=0; j<n; j++) {
+      if (A(i,j)) {
+        edges.push_back(j);
+        total_num_edges++;
+      }
+    }
+    vertices.push_back(total_num_edges);
+  }
+
+  // Use PMC to calculate
+  pmc::pmc_graph G(vertices, edges);
+  return G;
+}
+#endif
+
+// ----------------------------------------------------------------------------
+
+std::vector<int> solve(const Eigen::MatrixXd& A, const Params& params)
+{
+  // vector to represent max clique
+  std::vector<int> C;
+
+#ifdef CLIPPER_HAS_PMC
+  pmc::pmc_graph G = pmc_graph_from_adjmat(A);
+
+  if (params.verbose) {
+    G.basic_stats(0);
+  }
+
+  // used to silence cout from pmc library
+  std::streambuf * oldbuf;
+
+  // Prepare PMC input
+  pmc::input in;
+  in.algorithm = 0;
+  in.threads = params.threads;
+  in.experiment = 0;
+  in.lb = 0;
+  in.ub = 0;
+  in.param_ub = 0;
+  in.adj_limit = 20000;
+  in.time_limit = params.time_limit;
+  in.remove_time = 4;
+  in.graph_stats = false;
+  in.verbose = params.verbose;
+  in.help = false;
+  in.MCE = false;
+  in.decreasing_order = false;
+  in.heu_strat = "kcore";
+  in.vertex_search_order = "deg";
+
+  // upper-bound of max clique
+  G.compute_cores();
+  const int max_core = G.get_max_core();
+  if (in.ub == 0) in.ub = max_core + 1;
+
+
+  // check for k-core heuristic threshold
+  // check whether threshold equals 1 to short circuit the comparison
+  if (params.method == Method::KCORE) {
+    // remove all nodes with core number less than max core number
+    // k_cores is a vector saving the core number of each vertex
+    std::vector<int>* k_cores = G.get_kcores();
+    for (int i=1; i<k_cores->size(); ++i) {
+      // Note: k_core has size equals to num vertices + 1
+      if ((*k_cores)[i] >= max_core) {
+        C.push_back(i-1);
+      }
+    }
+    return C;
+  }
+
+  // lower-bound of max clique - skip if given as input
+  if (in.lb == 0 && in.heu_strat != "0") {
+    if (!params.verbose) oldbuf = std::cout.rdbuf(nullptr);
+    pmc::pmc_heu maxclique(G, in);
+    in.lb = maxclique.search(G, C);
+    if (!params.verbose) std::cout.rdbuf(oldbuf);
+  }
+
+  assert(in.lb != 0);
+  if (in.lb == 0) {
+    // This means that max clique has a size of one
+    return C;
+  }
+
+  if (params.method == Method::HEU || in.lb == in.ub) {
+    return C;
+  }
+
+  // Optional exact max clique finding
+  if (params.method == Method::EXACT) {
+    // The following methods are used:
+    // 1. k-core pruning
+    // 2. neigh-core pruning/ordering
+    // 3. dynamic coloring bounds/sort
+    // see the original PMC paper and implementation for details:
+    // R. A. Rossi, D. F. Gleich, and A. H. Gebremedhin, “Parallel Maximum Clique Algorithms with
+    // Applications to Network Analysis,” SIAM J. Sci. Comput., vol. 37, no. 5, pp. C589–C616, Jan.
+    // 2015.
+    if (!params.verbose) oldbuf = std::cout.rdbuf(nullptr);
+    if (G.num_vertices() < in.adj_limit) {
+      G.create_adj();
+      pmc::pmcx_maxclique finder(G, in);
+      finder.search_dense(G, C);
+    } else {
+      pmc::pmcx_maxclique finder(G, in);
+      finder.search(G, C);
+    }
+    if (!params.verbose) std::cout.rdbuf(oldbuf);
+  }
+#endif
+
+  return C;
+}
+
+} // ns maxclique
+} // ns clipper


### PR DESCRIPTION
Adds maximum clique solver

- using Ryan Rossi's [PMC library](https://github.com/ryanrossi/pmc), modified by Jingnan Shi for C++11 and hosted [here](https://github.com/jingnanshi/pmc)
- Only relies on third party code if CMake option `CLIPPER_ENABLE_MAXCLIQUE` is `ON` (`ON` by default)
- allows quick comparison between using weighted graphs and not using weighted graphs
- PMC is often fast given enough threads, but the exact method is solving an NP-hard problem so you have to be careful (i.e., if you don't want to wait exponential time, you basically have to know that you are operating in a high outlier regime)
- the main failure mode of using unweighted graphs is in the case where there is a small number of correct associations relative to the number of associations to choose from - thus, in high outlier regimes and with fewer total associations (e.g., 64) we see the most performance degradation, though on average, the maximum clique formulation never achieves 100% precision in the presence of outliers.
- unweighted graphs can also be ambiguous when there are competing maximum cliques
- clipper (weighted formulation) tends to trade off recall for precision

See also https://github.com/plusk01/maxclique

## maximum clique

```bash
Benchmarking over 20 trials


Benchmarking ρ = 90% [██████████████████████████████████████████████████] 100% [00m:53s]                                                                                                                       

+-------+---------+---------------+-------------------+---------------+------------+
| ρ [%] | # assoc | affinity [ms] | dense clique [ms] | precision [%] | recall [%] |
+-------+---------+---------------+-------------------+---------------+------------+
| 0     | 64      |  0.59  ±  0.6 |      1.28  ±  1.1 | 100           | 100        |
| 0     | 256     |  2.11  ±  1.8 |      2.10  ±  2.0 | 100           | 100        |
| 0     | 512     |  4.58  ±  0.8 |      6.22  ±  3.4 | 100           | 100        |
| 0     | 1024    | 20.39  ±  0.4 |     27.20  ± 11.7 | 100           | 100        |
| 0     | 2048    | 92.07  ±  6.1 |    160.32  ± 44.8 | 100           | 100        |
+-------+---------+---------------+-------------------+---------------+------------+
| 20    | 64      |  0.59  ±  0.9 |      0.85  ±  0.7 | 99            | 100        |
| 20    | 256     |  2.00  ±  1.3 |      1.34  ±  0.2 | 99            | 100        |
| 20    | 512     |  4.31  ±  0.7 |      3.81  ±  0.1 | 99            | 100        |
| 20    | 1024    | 15.11  ±  0.7 |     14.90  ±  0.9 | 99            | 100        |
| 20    | 2048    | 85.48  ±  1.7 |    115.33  ±  1.6 | 99            | 100        |
+-------+---------+---------------+-------------------+---------------+------------+
| 40    | 64      |  0.48  ±  0.5 |      1.26  ±  1.4 | 99            | 100        |
| 40    | 256     |  1.57  ±  0.9 |      1.20  ±  0.1 | 99            | 100        |
| 40    | 512     |  3.83  ±  0.3 |      3.19  ±  0.1 | 99            | 100        |
| 40    | 1024    | 14.19  ±  0.6 |     12.45  ±  0.6 | 99            | 100        |
| 40    | 2048    | 56.87  ±  4.1 |   169.99  ± 270.1 | 99            | 100        |
+-------+---------+---------------+-------------------+---------------+------------+
| 80    | 64      |  1.26  ±  2.5 |      1.94  ±  3.3 | 97            | 100        |
| 80    | 256     |  1.87  ±  1.4 |      2.72  ±  3.5 | 98            | 100        |
| 80    | 512     |  3.88  ±  0.8 |      2.48  ±  0.0 | 98            | 100        |
| 80    | 1024    | 14.59  ±  3.5 |     10.03  ±  1.4 | 99            | 100        |
| 80    | 2048    | 57.41  ±  7.9 |     78.85  ± 20.4 | 99            | 100        |
+-------+---------+---------------+-------------------+---------------+------------+
| 90    | 64      |  1.17  ±  1.6 |      2.33  ±  2.9 | 93            | 100        |
| 90    | 256     |  3.03  ±  3.0 |      2.30  ±  2.8 | 96            | 100        |
| 90    | 512     |  8.41  ±  6.6 |      3.44  ±  2.7 | 97            | 100        |
| 90    | 1024    | 24.39  ±  5.1 |      9.72  ±  1.0 | 97            | 100        |
| 90    | 2048    | 55.80  ±  9.4 |     66.88  ±  5.4 | 98            | 100        |
+-------+---------+---------------+-------------------+---------------+------------+
```

## clipper

```bash
Benchmarking over 20 trials

Benchmarking ρ = 90% [██████████████████████████████████████████████████] 100% [00m:44s]

+-------+---------+---------------+-------------------+---------------+------------+
| ρ [%] | # assoc | affinity [ms] | dense clique [ms] | precision [%] | recall [%] |
+-------+---------+---------------+-------------------+---------------+------------+
| 0     | 64      |  0.19  ±  0.0 |      0.06  ±  0.0 | 100           | 90         |
| 0     | 256     |  1.05  ±  0.0 |      0.63  ±  0.0 | 100           | 89         |
| 0     | 512     |  3.95  ±  0.1 |      2.41  ±  0.0 | 100           | 89         |
| 0     | 1024    | 15.64  ±  1.0 |      9.86  ±  0.1 | 100           | 89         |
| 0     | 2048    | 94.63  ±  1.4 |     32.53  ±  0.4 | 100           | 89         |
+-------+---------+---------------+-------------------+---------------+------------+
| 20    | 64      |  0.20  ±  0.0 |      0.06  ±  0.0 | 100           | 90         |
| 20    | 256     |  1.88  ±  3.9 |      0.63  ±  0.1 | 99            | 89         |
| 20    | 512     |  3.69  ±  0.1 |      2.35  ±  0.4 | 100           | 89         |
| 20    | 1024    | 14.84  ±  0.6 |     13.51  ±  6.3 | 99            | 89         |
| 20    | 2048    | 85.49  ±  1.5 |     59.20  ± 46.9 | 100           | 89         |
+-------+---------+---------------+-------------------+---------------+------------+
| 40    | 64      |  0.19  ±  0.0 |      0.04  ±  0.0 | 100           | 90         |
| 40    | 256     |  1.00  ±  0.1 |      0.42  ±  0.1 | 100           | 89         |
| 40    | 512     |  3.46  ±  0.1 |      1.58  ±  0.4 | 100           | 89         |
| 40    | 1024    | 13.77  ±  0.4 |      9.27  ±  3.6 | 99            | 89         |
| 40    | 2048    | 71.14  ±  1.1 |     55.42  ± 27.5 | 99            | 89         |
+-------+---------+---------------+-------------------+---------------+------------+
| 80    | 64      |  0.29  ±  0.5 |      0.05  ±  0.0 | 100           | 91         |
| 80    | 256     |  0.89  ±  0.0 |      0.44  ±  0.1 | 100           | 89         |
| 80    | 512     |  3.22  ±  0.1 |      1.62  ±  0.3 | 99            | 90         |
| 80    | 1024    | 12.54  ±  0.1 |      5.71  ±  1.3 | 99            | 90         |
| 80    | 2048    | 66.70  ±  0.5 |     24.55  ± 15.5 | 99            | 89         |
+-------+---------+---------------+-------------------+---------------+------------+
| 90    | 64      |  0.18  ±  0.0 |      0.05  ±  0.0 | 100           | 90         |
| 90    | 256     |  0.95  ±  0.3 |      0.38  ±  0.1 | 99            | 90         |
| 90    | 512     |  3.17  ±  0.1 |      1.44  ±  0.5 | 99            | 90         |
| 90    | 1024    | 12.37  ±  0.1 |      6.12  ±  1.7 | 99            | 90         |
| 90    | 2048    | 66.18  ±  0.3 |     27.09  ± 10.1 | 99            | 90         |
+-------+---------+---------------+-------------------+---------------+------------+
```